### PR TITLE
Compatibility with torch-1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ python train_ml1m_alter.py
 - `src/train_[dataset]_[regularization method].py`: entry point
 
 # Requirement
-- pytorch=0.4.0
+- pytorch=1.2.0
 
 # Citation
 If you this repo, please kindly cite our paper.

--- a/src/factorizer/factorizer.py
+++ b/src/factorizer/factorizer.py
@@ -52,7 +52,6 @@ class BPR_Factorizer(object):
         self._train_step_idx = None
         self._train_episode_idx = None
 
-        self.copy_count = 0
     # @profile
     def copy(self, new_factorizer):
         """Return a new copy of factorizer
@@ -60,13 +59,11 @@ class BPR_Factorizer(object):
         # Note: directly using deepcopy wont copy factorizer.scheduler correctly
                 the gradient of self.model is not copied!
         """
-        self.copy_count = self.copy_count + 1
-        #print(self.copy_count)
-        self.train_step_idx = deepcopy(new_factorizer.train_step_idx)
-        self.param = deepcopy(new_factorizer.param)
-        self.model.load_state_dict(deepcopy(new_factorizer.model.state_dict()))
+        self.train_step_idx = new_factorizer.train_step_idx
+        self.param = new_factorizer.param
+        self.model.load_state_dict(new_factorizer.model.state_dict())
         self.optimizer = use_optimizer(self.model, self.opt)
-        self.optimizer.load_state_dict(deepcopy(new_factorizer.optimizer.state_dict()))
+        self.optimizer.load_state_dict(new_factorizer.optimizer.state_dict())
 
         self.scheduler = ExponentialLR(self.optimizer,
                                       gamma=self.opt['lr_exp_decay'],


### PR DESCRIPTION
This version of code works fine in torch-1.2 by soving the wapper after wapper issue in torch-1.2 lr_scheduler.py. To be clear, the main branch of pytorch has already changed the problem code so the next version of pytorch release should works fine in original code.